### PR TITLE
Simplify the API and make it more idiomatic Rust.

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -141,31 +141,12 @@ impl Default for Edge {
     }
 }
 
-pub(super) fn _build_layout_from_edges(edges: &[(u32, u32)], config: Config) -> Layouts<usize> {
-    let graph = StableDiGraph::<Vertex, Edge>::from_edges(edges);
-    // initialize vertex ids to NodeIndex
-    start(graph, config)
-}
-
-pub(super) fn _build_layout_from_graph<T, E>(
-    graph: &StableDiGraph<T, E>,
-    config: Config,
-) -> Layouts<usize> {
-    // does this guarantee that ids will match?
-    let algo_graph = graph.map(|_, _| Vertex::default(), |_, _| Edge::default());
-    start(algo_graph, config)
-}
-
 pub(super) fn start(mut graph: StableDiGraph<Vertex, Edge>, config: Config) -> Layouts<usize> {
     init_graph(&mut graph);
     weakly_connected_components(graph)
         .into_iter()
         .map(|g| build_layout(g, config))
         .collect()
-}
-
-pub(super) fn _map_input_graph<V, E>(graph: &StableDiGraph<V, E>) -> StableDiGraph<Vertex, Edge> {
-    graph.map(|_, _| Vertex::default(), |_, _| Edge::default())
 }
 
 fn init_graph(graph: &mut StableDiGraph<Vertex, Edge>) {

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -141,7 +141,7 @@ impl Default for Edge {
     }
 }
 
-pub(super) fn start(mut graph: StableDiGraph<Vertex, Edge>, config: Config) -> Layouts<usize> {
+pub(super) fn start(mut graph: StableDiGraph<Vertex, Edge>, config: &Config) -> Layouts<usize> {
     init_graph(&mut graph);
     weakly_connected_components(graph)
         .into_iter()
@@ -159,7 +159,7 @@ fn init_graph(graph: &mut StableDiGraph<Vertex, Edge>) {
     }
 }
 
-fn build_layout(mut graph: StableDiGraph<Vertex, Edge>, config: Config) -> Layout {
+fn build_layout(mut graph: StableDiGraph<Vertex, Edge>, config: &Config) -> Layout {
     info!(target: "layouting", "Start building layout");
     info!(target: "layouting", "Configuration is: {:?}", config);
     // we don't remember the edges that where reversed for now, since they are

--- a/src/algorithm/p1_layering/tests.rs
+++ b/src/algorithm/p1_layering/tests.rs
@@ -434,6 +434,6 @@ mod integration {
         let mut cfg = Config::default();
         cfg.ranking_type = RankingType::Up;
         cfg.dummy_vertices = true;
-        crate::algorithm::start(graph, cfg);
+        crate::algorithm::start(graph, &cfg);
     }
 }

--- a/src/algorithm/p2_reduce_crossings/tests.rs
+++ b/src/algorithm/p2_reduce_crossings/tests.rs
@@ -260,7 +260,7 @@ mod insert_dummy_vertices {
         }
         let g = StableDiGraph::from_edges(&edges);
         let c = Config::default();
-        crate::algorithm::start(g, c);
+        crate::algorithm::start(g, &c);
     }
 }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -60,16 +60,22 @@ pub struct Config {
 }
 
 impl Config {
-    /// Create a new config by reading in environment variables.
-    /// See [CoordinatesBuilder::configure_from_env] for a detailed description of environment variables.
+    /// Read in configuration values from environment variables.
+    ///
+    /// Envs that can be set include:
+    ///
+    /// | ENV | values | default | description |
+    /// | --- | ------ | ------- | ----------- |
+    /// | RUST_GRAPH_MIN_LEN    | integer, > 0         | 1          | minimum edge length between layers |
+    /// | RUST_GRAPH_V_SPACING  | integer, > 0         | 10         | minimum spacing between vertices on the same layer |
+    /// | RUST_GRAPH_DUMMIES    | y \| n               | y          | if dummy vertices are included in the final layout |
+    /// | RUST_GRAPH_R_TYPE     | original \| minimize \| up \| down | minimize   | defines how vertices are places vertically |
+    /// | RUST_GRAPH_CROSS_MIN  | barycenter \| median | barycenter | which heuristic to use for crossing reduction |
+    /// | RUST_GRAPH_TRANSPOSE  | y \| n               | y          | if transpose function is used to further try to reduce crossings (may increase runtime significally for large graphs) |
+    /// | RUST_GRAPH_DUMMY_SIZE | float, 1 >= v > 0    | 1.0        |size of dummy vertices in final layout, if dummy vertices are included. this will squish the graph horizontally |
     pub fn new_from_env() -> Self {
-        let config = Self::default();
-        config.read_env()
-    }
+        let mut config = Self::default();
 
-    /// Updates the config by reading in environment variables.
-    /// See [CoordinatesBuilder::configure_from_env] for a detailed description of environment variables.
-    pub fn read_env(mut self) -> Self {
         let parse_bool = |x: String| match x.as_str() {
             "y" => Ok(true),
             "n" => Ok(false),
@@ -77,32 +83,32 @@ impl Config {
         };
 
         read_env!(
-            self.minimum_length,
+            config.minimum_length,
             (|x| x.parse::<u32>()),
             ENV_MINIMUM_LENGTH
         );
 
         read_env!(
-            self.c_minimization,
+            config.c_minimization,
             (TryFrom::try_from),
             ENV_CROSSING_MINIMIZATION
         );
 
-        read_env!(self.ranking_type, (TryFrom::try_from), ENV_RANKING_TYPE);
+        read_env!(config.ranking_type, (TryFrom::try_from), ENV_RANKING_TYPE);
 
         read_env!(
-            self.vertex_spacing,
+            config.vertex_spacing,
             (|x| x.parse::<usize>()),
             ENV_VERTEX_SPACING
         );
 
-        read_env!(self.dummy_vertices, parse_bool, ENV_DUMMY_VERTICES);
+        read_env!(config.dummy_vertices, parse_bool, ENV_DUMMY_VERTICES);
 
-        read_env!(self.dummy_size, (|x| x.parse::<f64>()), ENV_DUMMY_SIZE);
+        read_env!(config.dummy_size, (|x| x.parse::<f64>()), ENV_DUMMY_SIZE);
 
-        read_env!(self.transpose, parse_bool, ENV_TRANSPOSE);
+        read_env!(config.transpose, parse_bool, ENV_TRANSPOSE);
 
-        self
+        config
     }
 }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,12 +1,7 @@
-use std::{env, marker::PhantomData};
+use std::env;
 
-use log::{error, trace};
-use petgraph::stable_graph::{NodeIndex, StableDiGraph};
-
-use crate::{
-    algorithm::{self, Edge, Vertex},
-    Layouts,
-};
+use log::error;
+use petgraph::stable_graph::StableDiGraph;
 
 // Default values for configuration
 pub static MINIMUM_LENGTH_DEFAULT: u32 = 1;
@@ -195,170 +190,9 @@ impl From<CrossingMinimization> for &'static str {
     }
 }
 
-/// Can be used to configure the layout of the graph, via the builder pattern.
-///
-/// # Example
-/// ```
-/// use rust_sugiyama::from_edges;
-/// let edges = [(0, 1), (0, 2), (2, 3)];
-/// let coords = from_edges(&edges)
-///     .vertex_spacing(20) // vertices are at least 20px apart
-///     .dummy_vertices(false) // ignore dummy vertices when calculating layout
-///     .transpose(false) // don't use tranpose function during crossing minimization
-///     .build(); // build the layout
-/// ```
-pub struct CoordinatesBuilder<Input: IntoCoordinates> {
-    config: Config,
-    _inner: StableDiGraph<Vertex, Edge>,
-    pd: PhantomData<Input>,
-}
-
-impl<Input: IntoCoordinates> CoordinatesBuilder<Input> {
-    pub(super) fn new(graph: StableDiGraph<Vertex, Edge>) -> Self {
-        Self {
-            config: Config::default(),
-            _inner: graph,
-            pd: PhantomData,
-        }
-    }
-
-    /// Set the minimimum length, see [Config] for description
-    pub fn minimum_length(mut self, v: u32) -> Self {
-        trace!(target: "initializing",
-            "Setting minimum length to: {v}");
-        self.config.minimum_length = v;
-        self
-    }
-
-    /// Set the spacing between vertices, see [Config] for description
-    pub fn vertex_spacing(mut self, v: usize) -> Self {
-        trace!(target: "initializing",
-            "Setting vertex spacing to: {v}");
-        self.config.vertex_spacing = v;
-        self
-    }
-
-    /// Activate/deactivate dummy vertices, see [Config] for description
-    pub fn dummy_vertices(mut self, v: bool) -> Self {
-        trace!(target: "initializing",
-            "Has dummy vertices: {v}");
-        self.config.dummy_vertices = v;
-        self
-    }
-
-    /// Set the layering type, see [Config] for description
-    pub fn layering_type(mut self, v: RankingType) -> Self {
-        trace!(target: "initializing",
-            "using layering type: {v:?}");
-        self.config.ranking_type = v;
-        self
-    }
-
-    /// Set the crossing minimization heuristic, see [Config] for description
-    pub fn crossing_minimization(mut self, v: CrossingMinimization) -> Self {
-        trace!(target: "initializing",
-            "Heuristic for crossing minimization: {v:?}");
-        self.config.c_minimization = v;
-        self
-    }
-
-    /// Use transpose function during crossing minimization, see [Config]
-    pub fn transpose(mut self, v: bool) -> Self {
-        trace!(target: "initializing",
-            "Use transpose to further reduce crossings: {v}");
-        self.config.transpose = v;
-        self
-    }
-
-    /// Set the size of the dummy vertices, see [Config]
-    pub fn dummy_size(mut self, v: f64) -> Self {
-        trace!(target: "initializing",
-            "Dummy size in regards to vertex size: {v}");
-        self.config.dummy_size = v;
-        self
-    }
-
-    pub fn with_config(mut self, config: Config) -> Self {
-        trace!(target: "initializing",
-            "With config {:?}", config);
-        self.config = config;
-        self
-    }
-
-    /// Read in configuration values from environment variables.
-    ///
-    /// Envs that can be set include:
-    ///
-    /// | ENV | values | default | description |
-    /// | --- | ------ | ------- | ----------- |
-    /// | RUST_GRAPH_MIN_LEN    | integer, > 0         | 1          | minimum edge length between layers |
-    /// | RUST_GRAPH_V_SPACING  | integer, > 0         | 10         | minimum spacing between vertices on the same layer |
-    /// | RUST_GRAPH_DUMMIES    | y \| n               | y          | if dummy vertices are included in the final layout |
-    /// | RUST_GRAPH_R_TYPE     | original \| minimize \| up \| down | minimize   | defines how vertices are places vertically |
-    /// | RUST_GRAPH_CROSS_MIN  | barycenter \| median | barycenter | which heuristic to use for crossing reduction |
-    /// | RUST_GRAPH_TRANSPOSE  | y \| n               | y          | if transpose function is used to further try to reduce crossings (may increase runtime significally for large graphs) |
-    /// | RUST_GRAPH_DUMMY_SIZE | float, 1 >= v > 0    | 1.0        |size of dummy vertices in final layout, if dummy vertices are included. this will squish the graph horizontally |
-    pub fn configure_from_env(mut self) -> Self {
-        self.config = self.config.read_env();
-        self
-    }
-}
-
-impl<V, E> CoordinatesBuilder<StableDiGraph<V, E>> {
-    /// Build the layout.
-    pub fn build(self) -> Layouts<NodeIndex> {
-        let Self {
-            config,
-            _inner: graph,
-            ..
-        } = self;
-        algorithm::start(
-            graph.map(|_, _| Vertex::default(), |_, _| Edge::default()),
-            &config,
-        )
-        .into_iter()
-        .map(|(l, w, h)| {
-            (
-                l.into_iter()
-                    .map(|(id, coords)| (NodeIndex::from(id as u32), coords))
-                    .collect(),
-                w,
-                h,
-            )
-        })
-        .collect()
-    }
-}
-
-impl CoordinatesBuilder<&[(u32, u32)]> {
-    /// Build the layout.
-    pub fn build(self) -> Layouts<usize> {
-        let Self {
-            config,
-            _inner: graph,
-            ..
-        } = self;
-        algorithm::start(graph, &config)
-    }
-}
-
-impl CoordinatesBuilder<(&[u32], &[(u32, u32)])> {
-    /// Build the layout.
-    pub fn build(self) -> Layouts<usize> {
-        let Self {
-            config,
-            _inner: graph,
-            ..
-        } = self;
-        algorithm::start(graph, &config)
-    }
-}
-
 #[test]
 fn from_env_all_valid() {
-    use super::from_edges;
     use std::env;
-    let edges = [(1, 2), (2, 3)];
     env::set_var(ENV_MINIMUM_LENGTH, "5");
     env::set_var(ENV_DUMMY_VERTICES, "y");
     env::set_var(ENV_DUMMY_SIZE, "0.1");
@@ -366,34 +200,24 @@ fn from_env_all_valid() {
     env::set_var(ENV_CROSSING_MINIMIZATION, "median");
     env::set_var(ENV_TRANSPOSE, "n");
     env::set_var(ENV_VERTEX_SPACING, "20");
-    let cfg = from_edges(&edges).configure_from_env();
-    assert_eq!(cfg.config.minimum_length, 5);
-    assert_eq!(cfg.config.dummy_vertices, true);
-    assert_eq!(cfg.config.dummy_size, 0.1);
-    assert_eq!(cfg.config.ranking_type, RankingType::Up);
-    assert_eq!(cfg.config.c_minimization, CrossingMinimization::Median);
-    assert_eq!(cfg.config.transpose, false);
-    assert_eq!(cfg.config.vertex_spacing, 20);
+    let cfg = Config::new_from_env();
+    assert_eq!(cfg.minimum_length, 5);
+    assert_eq!(cfg.dummy_vertices, true);
+    assert_eq!(cfg.dummy_size, 0.1);
+    assert_eq!(cfg.ranking_type, RankingType::Up);
+    assert_eq!(cfg.c_minimization, CrossingMinimization::Median);
+    assert_eq!(cfg.transpose, false);
+    assert_eq!(cfg.vertex_spacing, 20);
 }
 
 #[test]
 fn from_env_invalid_value() {
-    use super::from_edges;
     use std::env;
 
-    let edges = [(1, 2)];
     env::set_var(ENV_CROSSING_MINIMIZATION, "flubbeldiflap");
     env::set_var(ENV_VERTEX_SPACING, "1.5");
-    let cfg = from_edges(&edges);
+    let cfg = Config::new_from_env();
     let default = Config::default();
-    assert_eq!(default.c_minimization, cfg.config.c_minimization);
-    assert_eq!(default.vertex_spacing, cfg.config.vertex_spacing);
-}
-
-#[test]
-fn run_algo_empty_graph() {
-    use super::from_edges;
-    let edges = [];
-    let g = from_edges(&edges).build();
-    assert!(g.is_empty());
+    assert_eq!(default.c_minimization, cfg.c_minimization);
+    assert_eq!(default.vertex_spacing, cfg.vertex_spacing);
 }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -314,7 +314,7 @@ impl<V, E> CoordinatesBuilder<StableDiGraph<V, E>> {
         } = self;
         algorithm::start(
             graph.map(|_, _| Vertex::default(), |_, _| Edge::default()),
-            config,
+            &config,
         )
         .into_iter()
         .map(|(l, w, h)| {
@@ -338,7 +338,7 @@ impl CoordinatesBuilder<&[(u32, u32)]> {
             _inner: graph,
             ..
         } = self;
-        algorithm::start(graph, config)
+        algorithm::start(graph, &config)
     }
 }
 
@@ -350,7 +350,7 @@ impl CoordinatesBuilder<(&[u32], &[(u32, u32)])> {
             _inner: graph,
             ..
         } = self;
-        algorithm::start(graph, config)
+        algorithm::start(graph, &config)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use algorithm::{Edge, Vertex};
-use configure::CoordinatesBuilder;
 
+use configure::Config;
 use log::info;
-use petgraph::stable_graph::StableDiGraph;
+use petgraph::{graph::NodeIndex, stable_graph::StableDiGraph};
 
 mod algorithm;
 pub mod configure;
@@ -12,37 +12,51 @@ mod util;
 
 type Layout = (Vec<(usize, (isize, isize))>, usize, usize);
 type Layouts<T> = Vec<(Vec<(T, (isize, isize))>, usize, usize)>;
-type RawGraph<'a> = (&'a [u32], &'a [(u32, u32)]);
 
 /// Creates a graph layout from edges, which are given as a `&[(u32, u32)]`.
 ///
-/// It returns a [CoordinatesBuilder] which can be used to configure the
-/// layout.
-pub fn from_edges(edges: &[(u32, u32)]) -> CoordinatesBuilder<&[(u32, u32)]> {
+/// The layouts are returned as a list of disjoint subgraphs containing the
+/// subgraph layout, the width, and the height. The layout of a subgraph is a
+/// list of the vertex number (as specified in the edges) and its x and y
+/// position respectively.
+pub fn from_edges(edges: &[(u32, u32)], config: &Config) -> Layouts<usize> {
     info!(target: "initializing", "Creating new layout from edges, containing {} edges", edges.len());
     let graph = StableDiGraph::from_edges(edges);
-    CoordinatesBuilder::new(graph)
+    algorithm::start(graph, config)
 }
 
-/// Creates a graph layout from a preexisting `StableDiGraph<V, E>`.
+/// Creates a graph layout from a preexisting [StableDiGraph<V, E>].
 ///
-/// It returns a [CoordinatesBuilder] which can be used to configure the
-/// layout.
-pub fn from_graph<V, E>(graph: &StableDiGraph<V, E>) -> CoordinatesBuilder<StableDiGraph<V, E>> {
+/// The layouts are returned as a list of disjoint subgraphs containing the
+/// subgraph layout, the width, and the height. The layout of a subgraph is a
+/// list of the [NodeIndex] and its x and y position respectively.
+pub fn from_graph<V, E>(graph: &StableDiGraph<V, E>, config: &Config) -> Layouts<NodeIndex> {
     info!(target: "initializing", 
         "Creating new layout from existing graph, containing {} vertices and {} edges.", 
         graph.node_count(), 
         graph.edge_count());
 
     let graph = graph.map(|id, _| Vertex::new(id.index()), |_, _| Edge::default());
-    CoordinatesBuilder::new(graph)
+    algorithm::start(graph, config)
+        .into_iter()
+        .map(|(l, w, h)| {
+            (
+                l.into_iter()
+                    .map(|(id, coords)| (NodeIndex::from(id as u32), coords))
+                    .collect(),
+                w,
+                h,
+            )
+        })
+        .collect()
 }
 
 /// Creates a graph layot from `&[u32]` (vertices)
 /// and `&[(u32, u32)]` (edges).
 ///
-/// It returns a [CoordinatesBuilder] which can be used to configure the
-/// layout.
+/// The layouts are returned as a list of disjoint subgraphs containing the
+/// subgraph layout, the width, and the height. The layout of a subgraph is a
+/// list of the vertex number and its x and y position respectively.
 ///
 /// # Panics
 ///
@@ -50,7 +64,8 @@ pub fn from_graph<V, E>(graph: &StableDiGraph<V, E>) -> CoordinatesBuilder<Stabl
 pub fn from_vertices_and_edges<'a>(
     vertices: &'a [u32],
     edges: &'a [(u32, u32)],
-) -> CoordinatesBuilder<RawGraph<'a>> {
+    config: &Config,
+) -> Layouts<usize> {
     info!(target: "initializing", 
         "Creating new layout from existing graph, containing {} vertices and {} edges.", 
         vertices.len(), 
@@ -71,11 +86,20 @@ pub fn from_vertices_and_edges<'a>(
         );
     }
 
-    CoordinatesBuilder::new(graph)
+    algorithm::start(graph, config)
+}
+
+#[test]
+fn run_algo_empty_graph() {
+    let edges = [];
+    let g = from_edges(&edges, &Config::default());
+    assert!(g.is_empty());
 }
 
 #[cfg(test)]
 mod benchmark {
+    use crate::configure::Config;
+
     use super::from_edges;
 
     #[test]
@@ -86,7 +110,7 @@ mod benchmark {
             .map(|(r, l)| (r as u32, l as u32))
             .collect::<Vec<(u32, u32)>>();
         let start = std::time::Instant::now();
-        let _ = from_edges(&edges).build();
+        let _ = from_edges(&edges, &Config::default());
         println!("Random 100 edges: {}ms", start.elapsed().as_millis());
     }
 
@@ -98,7 +122,7 @@ mod benchmark {
             .map(|(r, l)| (r as u32, l as u32))
             .collect::<Vec<(u32, u32)>>();
         let start = std::time::Instant::now();
-        let _ = from_edges(&edges).build();
+        let _ = from_edges(&edges, &Config::default());
         println!("Random 1000 edges: {}ms", start.elapsed().as_millis());
     }
 
@@ -106,7 +130,7 @@ mod benchmark {
     fn r_2000() {
         let edges = graph_generator::RandomLayout::new(2000).build_edges();
         let start = std::time::Instant::now();
-        let _ = from_edges(&edges).build();
+        let _ = from_edges(&edges, &Config::default());
         println!("Random 2000 edges: {}ms", start.elapsed().as_millis());
     }
 
@@ -114,7 +138,7 @@ mod benchmark {
     fn r_4000() {
         let edges = graph_generator::RandomLayout::new(4000).build_edges();
         let start = std::time::Instant::now();
-        let _ = from_edges(&edges).build();
+        let _ = from_edges(&edges, &Config::default());
         println!("Random 4000 edges: {}ms", start.elapsed().as_millis());
     }
 
@@ -124,7 +148,7 @@ mod benchmark {
         let e = 2;
         let edges = graph_generator::GraphLayout::new_from_num_nodes(n, e).build_edges();
         let start = std::time::Instant::now();
-        let _ = from_edges(&edges).build();
+        let _ = from_edges(&edges, &Config::default());
         println!(
             "{n} nodes, {e} edges per node: {}ms",
             start.elapsed().as_millis()
@@ -137,7 +161,7 @@ mod benchmark {
         let e = 2;
         let edges = graph_generator::GraphLayout::new_from_num_nodes(n, e).build_edges();
         let start = std::time::Instant::now();
-        let _ = from_edges(&edges).build();
+        let _ = from_edges(&edges, &Config::default());
         println!(
             "{n} nodes, {e} edges per node: {}ms",
             start.elapsed().as_millis()
@@ -150,7 +174,7 @@ mod benchmark {
         let e = 2;
         let edges = graph_generator::GraphLayout::new_from_num_nodes(n, e).build_edges();
         let start = std::time::Instant::now();
-        let _ = from_edges(&edges).build();
+        let _ = from_edges(&edges, &Config::default());
         println!(
             "{n} nodes, {e} edges per node: {}ms",
             start.elapsed().as_millis()
@@ -163,7 +187,7 @@ mod benchmark {
         let e = 2;
         let edges = graph_generator::GraphLayout::new_from_num_nodes(n, e).build_edges();
         let start = std::time::Instant::now();
-        let _ = from_edges(&edges).build();
+        let _ = from_edges(&edges, &Config::default());
         println!(
             "{n} nodes, {e} edges per node: {}ms",
             start.elapsed().as_millis()
@@ -174,7 +198,10 @@ mod benchmark {
 #[cfg(test)]
 mod check_visuals {
 
-    use crate::from_vertices_and_edges;
+    use crate::{
+        configure::{Config, RankingType},
+        from_vertices_and_edges,
+    };
 
     use super::from_edges;
 
@@ -211,9 +238,14 @@ mod check_visuals {
             (15, 19),
             (15, 13),
         ];
-        let _ = from_vertices_and_edges(&vertices, &edges)
-            .dummy_vertices(true)
-            .build();
+        let _ = from_vertices_and_edges(
+            &vertices,
+            &edges,
+            &Config {
+                dummy_vertices: true,
+                ..Default::default()
+            },
+        );
     }
     #[test]
     fn verify_looks_good() {
@@ -236,7 +268,7 @@ mod check_visuals {
             (7, 9),
             (8, 9),
         ];
-        let (layout, width, height) = &mut from_edges(&edges).build()[0];
+        let (layout, width, height) = &mut from_edges(&edges, &Config::default())[0];
         layout.sort_by(|a, b| a.0.cmp(&b.0));
 
         assert_eq!(*width, 4);
@@ -247,7 +279,7 @@ mod check_visuals {
     #[test]
     fn root_vertices_on_top_disabled() {
         let edges = [(1, 0), (2, 1), (3, 0), (4, 0)];
-        let layout = from_edges(&edges).build();
+        let layout = from_edges(&edges, &Config::default());
         for (id, (_, y)) in layout[0].0.clone() {
             if id == 2 {
                 assert_eq!(y, 0);
@@ -274,7 +306,7 @@ mod check_visuals {
             (3, 8),
             (3, 9),
         ];
-        let layout = from_edges(&edges).build();
+        let layout = from_edges(&edges, &Config::default());
         println!("{:?}", layout);
     }
 
@@ -333,9 +365,13 @@ mod check_visuals {
         .map(|(t, h)| (t - 1, h - 1))
         .collect::<Vec<_>>();
 
-        let layout = from_edges(&edges)
-            .layering_type(crate::configure::RankingType::Up)
-            .build();
+        let layout = from_edges(
+            &edges,
+            &Config {
+                ranking_type: RankingType::Up,
+                ..Default::default()
+            },
+        );
         println!("{layout:?}");
     }
 
@@ -343,7 +379,7 @@ mod check_visuals {
     fn run_algo_empty_graph() {
         use super::from_edges;
         let edges = [];
-        let g = from_edges(&edges).build();
+        let g = from_edges(&edges, &Config::default());
         assert!(g.is_empty());
     }
 
@@ -366,7 +402,7 @@ mod check_visuals {
             (5, 1),
         ];
 
-        let layout = from_edges(&edges).build();
+        let layout = from_edges(&edges, &Config::default());
         println!("{layout:?}");
     }
 }


### PR DESCRIPTION
Builder patterns aren't too common and should be avoided unless there is a really compelling case.

Here, we're just building a config file up. Users can instead just initialize a struct like they normally do.

```rust
// Most basic API
from_graph(graph, &Config::default());

// Changing some config values.
from_graph(graph, &Config{
    dummy_vertices: true,
    ..Default::default()
});

// Using the environment variables, but explicitly setting one field.
from_graph(graph, &Config {
    dummy_vertices: true,
    ..Config::new_from_env()
});
```

I am skeptical we should even have `new_from_env` - that seems like something the user should be doing themselves, but perhaps that's a separate PR.