### PR TITLE
fix duplicated x locations in some layouts

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -314,3 +314,51 @@ fn print_to_console(
     }
     println!();
 }
+
+#[test]
+fn is_valid_layout() {
+    fn has_duplicates<T: Eq + std::hash::Hash>(vec: &[T]) -> bool {
+        let mut seen = std::collections::HashSet::new();
+        for item in vec {
+            let is_new = seen.insert(item);
+            if !is_new {
+                return true; // Found a duplicate
+            }
+        }
+        false // No duplicates found
+    }
+
+    fn layout_is_valid(layout: &[(usize, (f64, f64))]) -> bool {
+        let rank_scale = 2_i64.pow(31) as f64; // make space to pack x & y into an i64
+        let xs = layout
+            .iter()
+            .map(|(_s, (x, y))| (y * rank_scale + x * 100.0).round() as i64)
+            .collect::<Vec<_>>();
+
+        !has_duplicates(&xs)
+    }
+
+    // this graph failed to create a valid layout
+    // in versions <= 0.3
+    let edges = [
+        (2, 1),
+        (3, 1),
+        (7, 4),
+        (8, 7),
+        (9, 2),
+        (10, 1),
+        (4, 2),
+        (6, 1),
+        (11, 4),
+        (5, 4),
+        (12, 1),
+    ];
+
+    let graph = StableDiGraph::from_edges(edges);
+
+    let layouts = start(graph, &Config::default());
+
+    for (positions, _, _) in layouts {
+        assert!(layout_is_valid(&positions));
+    }
+}

--- a/src/algorithm/p3_calculate_coordinates/mod.rs
+++ b/src/algorithm/p3_calculate_coordinates/mod.rs
@@ -113,7 +113,8 @@ pub(crate) fn calculate_relative_coords(
     // try to use something like mean
     sorted_layouts
         .into_iter()
-        .map(|(k, v)| (*k, (v[0] + v[1] + v[2] + v[3]) / 4.0))
+        // "the average median is both order and separation preserving" [Brandes & Kopf, 2001]
+        .map(|(k, v)| (*k, (v[1] + v[2]) / 2.0))
         .collect::<Vec<_>>()
 }
 
@@ -262,7 +263,7 @@ fn do_horizontal_compaction(
                     v = graph[v].align;
                     j += 1;
 
-                    if graph[v].pos > 1 {
+                    if graph[v].pos > 0 {
                         let u = pred(graph[v], layers);
                         let gap = (graph[v].block_max_vertex_width
                             + graph[u].block_max_vertex_width)


### PR DESCRIPTION
This fixes an issue that causes blocks to be placed and shifted into positions that conflict with already placed blocks.

The origin of the bug appears to be in how the block placement algorithm from the paper [Brandes & Kopf](https://link.springer.com/content/pdf/10.1007/3-540-45848-4_3) & its [errata](https://arxiv.org/pdf/2008.01252) are notated -- the paper uses 1 indexing (fortran) rather than 0 (c style / rust style).

Additionally, the current implementation on main uses an average of all 4 candidate layout coordinates, but this PR switches this back to the avg median per the paper since "the average median is order and separation preserving" [Brandes & Kopf, 2001].

Closes #22 

I have also added a test that fails on main & v3 but passes with this fix. not sure how bullet proof you want to go with this, but the checker functions that are embedded in the test could be easily added into the 'start' function where a user or test could toggle the layout checker. lmk if you'd like to see what that looks like, i have an option drafted that adds another flag to the config and could put it in another PR that builds on this one.